### PR TITLE
Reverted to empty onclick fns

### DIFF
--- a/fly2plan-react-gui/src/components/AgentHolder/ColumnLeft/CredentialSetItem/CredentialSetItem.js
+++ b/fly2plan-react-gui/src/components/AgentHolder/ColumnLeft/CredentialSetItem/CredentialSetItem.js
@@ -42,14 +42,24 @@ export default function CredentialSetItem({
       <div className="card-body">
         <p className="card-text mt-2 small">
           Timestamp:&nbsp;
-          <a href="#/" title={timestamp} className="text-primary">
+          <a
+            href="/#"
+            onClick={(e) => e.preventDefault()}
+            title={timestamp}
+            className="text-primary"
+          >
             {new Date(timestamp * 1000)
               .toISOString()
               .slice(0, 19)
               .replace('T', ' ')}
           </a>
           &nbsp;|&nbsp; DefId:&nbsp;
-          <a href="#/" title={cred_def_id} className="text-primary">
+          <a
+            href="/#"
+            onClick={(e) => e.preventDefault()}
+            title={cred_def_id}
+            className="text-primary"
+          >
             {cred_def_id.slice(0, 2)}…:{cred_def_id.split(':')[4]}
           </a>
         </p>

--- a/fly2plan-react-gui/src/components/AgentHolder/ColumnRight/ColumnRightWrap/ColumnRightWrap.js
+++ b/fly2plan-react-gui/src/components/AgentHolder/ColumnRight/ColumnRightWrap/ColumnRightWrap.js
@@ -68,7 +68,11 @@ export default function ColumnRightWrap({ origin }) {
                 View all present-proof records ( &nbsp;
                 <b>
                   Config – Automatically reply to proof request
-                  <a href="/#" className="text-primary">
+                  <a
+                    href="/#"
+                    onClick={(e) => e.preventDefault()}
+                    className="text-primary"
+                  >
                     &nbsp; ON &nbsp;
                   </a>
                 </b>

--- a/fly2plan-react-gui/src/components/AgentHolder/ColumnRight/TableEvent/TableEvent.js
+++ b/fly2plan-react-gui/src/components/AgentHolder/ColumnRight/TableEvent/TableEvent.js
@@ -76,7 +76,12 @@ export default function TableEvent({ i, j, k, eId, cId, event }) {
             </td>
             <td>
               <b>ConnId: </b>
-              <a href="/#" title={cId} className="text-primary">
+              <a
+                href="/#"
+                onClick={(e) => e.preventDefault()}
+                title={cId}
+                className="text-primary"
+              >
                 {getShortenId(cId)}
               </a>
             </td>
@@ -91,6 +96,7 @@ export default function TableEvent({ i, j, k, eId, cId, event }) {
               <a
                 href="/#"
                 className="text-primary"
+                onClick={(e) => e.preventDefault()}
                 title={getDefIdFull(event.by_format)}
               >
                 {getDefId(event.by_format)}
@@ -98,7 +104,12 @@ export default function TableEvent({ i, j, k, eId, cId, event }) {
             </td>
             <td>
               <b>ExId: </b>
-              <a href="/#" className="text-primary" title={eId}>
+              <a
+                href="/#"
+                className="text-primary"
+                onClick={(e) => e.preventDefault()}
+                title={eId}
+              >
                 {getShortenId(eId)}
               </a>
             </td>


### PR DESCRIPTION
---
name: Unwanted page re-render when clicking on some links
about: The GUI seems to re-render the page when clicking on some links ( they need empty onClick functions )
---

<!--

Have you read {project_name}'s Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/digicatapult/veritable-poc/.github/blob/main/CODE_OF_CONDUCT.md

-->

### Prerequisites

Nothing new here

### Description

<!-- Description of the issue -->

### Steps to Reproduce

1. Start everything including the entire user flow
2. In the Holder GUI start clicking on every link that's designed to have light blue colour

**Expected behaviour:**

The page should not re-render

### Additional Information

Those links need to be accompanied by something like `onClick={(e) => e.preventDefault()}` to make not do anything when user clicks on them.

![img](https://i.imgur.com/8Jad8p4.png)

This should fix the problem.
